### PR TITLE
ci: Docker packaging + GitHub Actions CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.git
+.github
+tests
+environment.json
+environment-test.json
+public/uploads
+npm-debug.log
+*.log
+.DS_Store
+.eslintcache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx eslint src/app.js src/**/*.js
+
+      - run: npx ava
+        env:
+          NODE_ENV: test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,76 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [master]
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build-and-push:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - id: tag
+        run: echo "tag=${{ github.event.workflow_run.head_sha }}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.tag.outputs.tag }}
+            ${{ env.IMAGE }}:latest
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy over SSH and health-check
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/movie-manager-api
+            echo "${{ secrets.GHCR_READ_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "IMAGE_TAG=${{ needs.build-and-push.outputs.tag }}" > .env
+            docker compose pull
+            docker compose run --rm api npm run db:sync
+            docker compose up -d
+
+            # environment.json already lives here for the pm2 deploy today,
+            # so node is a safe assumption on this host.
+            PORT=$(node -e "console.log(require('./environment.json').port)")
+            for i in $(seq 1 10); do
+              if curl -sf -X POST "http://localhost:$PORT/graphql" \
+                -H "Content-Type: application/json" \
+                -d '{"query":"{ __typename }"}' > /dev/null; then
+                echo "Health check passed"
+                exit 0
+              fi
+              sleep 3
+            done
+            echo "Health check failed after deploy -- consider running the rollback workflow"
+            exit 1

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,45 @@
+name: Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Image tag to redeploy (git SHA of a previous successful deploy, or 'latest')"
+        required: true
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  rollback:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Redeploy previous image over SSH and health-check
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_SSH_HOST }}
+          username: ${{ secrets.DEPLOY_SSH_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/movie-manager-api
+            echo "${{ secrets.GHCR_READ_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            echo "IMAGE_TAG=${{ inputs.image_tag }}" > .env
+            docker compose pull
+            docker compose up -d
+
+            # No db:sync here: rolling back to an older image should not
+            # re-run schema sync against a newer schema shape.
+            PORT=$(node -e "console.log(require('./environment.json').port)")
+            for i in $(seq 1 10); do
+              if curl -sf -X POST "http://localhost:$PORT/graphql" \
+                -H "Content-Type: application/json" \
+                -d '{"query":"{ __typename }"}' > /dev/null; then
+                echo "Health check passed"
+                exit 0
+              fi
+              sleep 3
+            done
+            echo "Health check failed after rollback"
+            exit 1

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,41 @@
+# Deployment
+
+CI/CD runs through GitHub Actions (`.github/workflows/ci.yml`, `deploy.yml`, `rollback.yml`). On every push to `master` that passes CI, a Docker image is built, pushed to GitHub Container Registry (`ghcr.io/laurentchin/movie-manager-api`), tagged with the commit SHA (and `latest`), then deployed to the production server over SSH.
+
+## One-time server setup
+
+These steps have to be done manually on the production server (`kimsufi`) — nothing here can be run from CI.
+
+1. **Install Docker + the Compose plugin.**
+
+2. **Create the deploy directory:**
+   ```bash
+   mkdir -p /opt/movie-manager-api/uploads
+   ```
+
+3. **Copy `docker-compose.yml`** from this repo into `/opt/movie-manager-api/`.
+
+4. **Create `/opt/movie-manager-api/environment.json`** with production config — same shape as the `environment.json` used today for the pm2 deploy, but `assetsPath` should point at the path *inside the container*: `/app/public`. Keep `database.config.host` as `"localhost"` — the container runs with `network_mode: host`, so it reaches Postgres exactly like the pm2 process does today.
+
+5. **Move existing uploaded posters** into `/opt/movie-manager-api/uploads/` (the directory shipit currently keeps as a shared dir), so they carry over.
+
+6. **Create a GitHub Personal Access Token** (scope: `read:packages`) so the server can `docker login ghcr.io` and pull images from this private repo.
+
+## GitHub repository secrets
+
+Add these under Settings → Secrets and variables → Actions:
+
+| Secret | Value |
+|---|---|
+| `DEPLOY_SSH_HOST` | Server hostname/IP |
+| `DEPLOY_SSH_USER` | SSH user (e.g. `laurent`) |
+| `DEPLOY_SSH_KEY` | Private key with access to the server |
+| `GHCR_READ_TOKEN` | The PAT from step 6 above |
+
+## Rollback
+
+Actions tab → **Rollback** workflow → *Run workflow* → enter the image tag to redeploy (a previous commit SHA, visible in the `deploy.yml` run history or in the [package versions](https://github.com/laurentChin/movie-manager-api/pkgs/container/movie-manager-api) on GitHub). No rebuild — it pulls the already-published image and restarts the container. `db:sync` is deliberately **not** run on rollback, to avoid syncing an older schema against a newer database state.
+
+## What's not migrated yet
+
+`shipitfile.js` (the old `shipit-cli` pm2-based deploy) is still in the repo, kept as a fallback until the pipeline above is confirmed working in production. Remove it (and the `shipit-*` devDependencies) once a real deploy + rollback have both been exercised successfully.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -8,18 +8,40 @@ These steps have to be done manually on the production server (`kimsufi`) — no
 
 1. **Install Docker + the Compose plugin.**
 
-2. **Create the deploy directory:**
+2. **Create a dedicated system user for GitHub Actions** — don't reuse a personal account. Ubuntu 26.04:
    ```bash
-   mkdir -p /opt/movie-manager-api/uploads
+   sudo adduser --disabled-password --gecos "" deploy
+   sudo usermod -aG docker deploy
+   ```
+   `--disabled-password` means there's no password to log in with at all — SSH key only. Deliberately **not** added to `sudo`.
+
+   Note: `docker` group membership is effectively root-equivalent on this host (a container can bind-mount the host filesystem), because the workflows run `docker`/`docker compose` directly over SSH with no `sudo`. That's an accepted tradeoff for a personal single-purpose deploy account here — if you'd rather avoid it, a narrower `/etc/sudoers.d/deploy` allowlist restricted to specific `docker compose`/`docker login`/`docker pull` commands is the harder alternative; ask if you want that version instead.
+
+3. **Generate a dedicated keypair** for this — don't reuse your own SSH key. From your own machine (not the server):
+   ```bash
+   ssh-keygen -t ed25519 -C "github-actions@movie-manager-api" -f ~/.ssh/movie_manager_deploy -N ""
+   ```
+   Then copy the **public** half to the server, for the `deploy` user specifically:
+   ```bash
+   ssh-copy-id -i ~/.ssh/movie_manager_deploy.pub deploy@<server-host>
+   ```
+   (If `ssh-copy-id` isn't available or `deploy` can't log in yet to receive it, log in as an admin account instead and append the `.pub` file's contents to `/home/deploy/.ssh/authorized_keys` manually, then `chown -R deploy:deploy /home/deploy/.ssh && chmod 700 /home/deploy/.ssh && chmod 600 /home/deploy/.ssh/authorized_keys`.)
+
+   The **private** half (`~/.ssh/movie_manager_deploy`, no `.pub`) is what goes into the `DEPLOY_SSH_KEY` GitHub secret below — never the public one.
+
+4. **Create the deploy directory, owned by `deploy`:**
+   ```bash
+   sudo mkdir -p /opt/movie-manager-api/uploads
+   sudo chown -R deploy:deploy /opt/movie-manager-api
    ```
 
-3. **Copy `docker-compose.yml`** from this repo into `/opt/movie-manager-api/`.
+5. **Copy `docker-compose.yml`** from this repo into `/opt/movie-manager-api/`.
 
-4. **Create `/opt/movie-manager-api/environment.json`** with production config — same shape as the `environment.json` used today for the pm2 deploy, but `assetsPath` should point at the path *inside the container*: `/app/public`. Keep `database.config.host` as `"localhost"` — the container runs with `network_mode: host`, so it reaches Postgres exactly like the pm2 process does today.
+6. **Create `/opt/movie-manager-api/environment.json`** with production config — same shape as the `environment.json` used today for the pm2 deploy, but `assetsPath` should point at the path *inside the container*: `/app/public`. Keep `database.config.host` as `"localhost"` — the container runs with `network_mode: host`, so it reaches Postgres exactly like the pm2 process does today.
 
-5. **Move existing uploaded posters** into `/opt/movie-manager-api/uploads/` (the directory shipit currently keeps as a shared dir), so they carry over.
+7. **Move existing uploaded posters** into `/opt/movie-manager-api/uploads/` (the directory shipit currently keeps as a shared dir), so they carry over.
 
-6. **Create a GitHub Personal Access Token** (scope: `read:packages`) so the server can `docker login ghcr.io` and pull images from this private repo.
+8. **Create a GitHub Personal Access Token** (scope: `read:packages`) so the server can `docker login ghcr.io` and pull images from this private repo.
 
 ## GitHub repository secrets
 
@@ -28,9 +50,9 @@ Add these under Settings → Secrets and variables → Actions:
 | Secret | Value |
 |---|---|
 | `DEPLOY_SSH_HOST` | Server hostname/IP |
-| `DEPLOY_SSH_USER` | SSH user (e.g. `laurent`) |
-| `DEPLOY_SSH_KEY` | Private key with access to the server |
-| `GHCR_READ_TOKEN` | The PAT from step 6 above |
+| `DEPLOY_SSH_USER` | `deploy` |
+| `DEPLOY_SSH_KEY` | Contents of the **private** key file from step 3 (`~/.ssh/movie_manager_deploy`) |
+| `GHCR_READ_TOKEN` | The PAT from step 8 above |
 
 ## Rollback
 

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -21,11 +21,15 @@ These steps have to be done manually on the production server (`kimsufi`) — no
    ```bash
    ssh-keygen -t ed25519 -C "github-actions@movie-manager-api" -f ~/.ssh/movie_manager_deploy -N ""
    ```
-   Then copy the **public** half to the server, for the `deploy` user specifically:
+   `deploy` has no password and no key yet, so plain `ssh-copy-id deploy@<host>` fails with `Permission denied (publickey)` — there's nothing to authenticate with as `deploy` yet. Install the public key through an existing admin account instead (substitute your actual admin user for `laurent`):
    ```bash
-   ssh-copy-id -i ~/.ssh/movie_manager_deploy.pub deploy@<server-host>
+   cat ~/.ssh/movie_manager_deploy.pub | ssh laurent@<server-host> "sudo mkdir -p /home/deploy/.ssh && sudo tee -a /home/deploy/.ssh/authorized_keys > /dev/null && sudo chmod 700 /home/deploy/.ssh && sudo chmod 600 /home/deploy/.ssh/authorized_keys && sudo chown -R deploy:deploy /home/deploy/.ssh"
    ```
-   (If `ssh-copy-id` isn't available or `deploy` can't log in yet to receive it, log in as an admin account instead and append the `.pub` file's contents to `/home/deploy/.ssh/authorized_keys` manually, then `chown -R deploy:deploy /home/deploy/.ssh && chmod 700 /home/deploy/.ssh && chmod 600 /home/deploy/.ssh/authorized_keys`.)
+   Verify it worked:
+   ```bash
+   ssh -i ~/.ssh/movie_manager_deploy deploy@<server-host> "whoami && groups"
+   ```
+   Should print `deploy` and a group list including `docker`.
 
    The **private** half (`~/.ssh/movie_manager_deploy`, no `.pub`) is what goes into the `DEPLOY_SSH_KEY` GitHub secret below — never the public one.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:22-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+FROM node:22-alpine
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NODE_ENV=production
+
+CMD ["node", "public/index.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+services:
+  api:
+    image: ghcr.io/laurentchin/movie-manager-api:${IMAGE_TAG:-latest}
+    container_name: movie-manager-api
+    # Postgres runs on the host, and environment.json's database.config.host
+    # is "localhost" -- host networking keeps that working unchanged, and
+    # exposes the app's port directly on the host like pm2 did before.
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+      - ./environment.json:/app/environment.json:ro
+      - ./uploads:/app/public/uploads


### PR DESCRIPTION
## Summary

Replaces the manual `shipit-cli` + pm2 deploy flow with GitHub Actions CI/CD, packaging the API as a Docker image with tag-based rollback (no rebuild needed).

- **`Dockerfile`** (multi-stage, `node:22-alpine`): `npm ci --omit=dev` runs inside the container so `sharp` resolves its own musl prebuilt binary automatically — confirmed with a real `docker build`.
- **`docker-compose.yml`**: `network_mode: host`, not bridge. Postgres runs on the same host as the API today (`environment.json`'s `database.config.host` is `"localhost"`); host networking keeps that working completely unchanged, and exposes the app's port on the host exactly like pm2 does now — nothing changes for whatever reverse proxy sits in front of it. `environment.json` and `public/uploads` stay as host files/dirs, bind-mounted in — zero application code changes needed. The image tag comes from an `IMAGE_TAG` env var (compose reads a `.env` file next to it), so rollback never needs a rebuild: ghcr.io keeps every previously pushed tag.
- **`.github/workflows/ci.yml`**: runs eslint + the 3 `ava` tests on push/PR. Deliberately calls eslint/ava directly rather than `npm run pretest`/`npm test` — those scripts end with `; exit 0` by design (so they never block local `npm start`), which would make this CI gate always green even on a real failure.
- **`.github/workflows/deploy.yml`**: triggers when CI succeeds on `master`, builds+pushes the image to ghcr.io tagged with the commit SHA and `latest`, then SSHes in to pull it, run `db:sync` (matching what shipit does today), restart the container, and poll the GraphQL endpoint as a post-deploy health check — fails the workflow (not an auto-rollback) if the new container doesn't come up healthy.
- **`.github/workflows/rollback.yml`**: `workflow_dispatch`, takes an image tag input, redeploys it. Deliberately skips `db:sync` — rolling back to an older image shouldn't run a newer schema sync against the database.
- **`DEPLOY.md`**: everything that had to happen outside this repo — a dedicated unprivileged `deploy` system user + dedicated SSH keypair (not a personal account/key) for GitHub Actions, the `/opt/movie-manager-api/` server layout, the GHCR PAT, and the 4 repo secrets the workflows need.

**Already done on the real infrastructure** (not just documented): the dedicated `deploy` user + SSH key are created and installed on the server, Docker + Compose are installed, `/opt/movie-manager-api/` exists with `environment.json` and `uploads/`, and all 4 GitHub secrets (`DEPLOY_SSH_HOST`, `DEPLOY_SSH_USER`, `DEPLOY_SSH_KEY`, `GHCR_READ_TOKEN`) are set on the repo. This PR's `deploy.yml` run (once merged to `master`) will be the first real end-to-end test against production.

`shipitfile.js` is intentionally kept in place for now as a fallback — to be removed in a follow-up once a real deploy + rollback have both been exercised successfully through the new pipeline.

## Test plan

- [x] `docker build` succeeds locally
- [x] A container built from that image smoke-tested end-to-end against the real local Postgres (login, `movies`, `search`, `explore`, a real multipart poster upload confirmed to land on the bind-mounted host volume, the `/uploads` placeholder fallback, `/formats` auth gating)
- [x] `docker compose config` validates the committed compose file
- [x] `actionlint` reports zero issues on all three workflow files
- [x] Dedicated deploy user/key verified working against the real server (`ssh -i ~/.ssh/movie_manager_deploy deploy@<host> "whoami && groups"` → `deploy` + `docker` group)
- [ ] First real `deploy.yml` run against production (happens on merge — this is the actual end-to-end validation of the SSH/GHCR/compose chain that can't be tested from here)
- [ ] A real rollback via `rollback.yml`, once there are at least two deployed tags to roll between

🤖 Generated with [Claude Code](https://claude.com/claude-code)