### PR TITLE
fix: lowercase the ghcr.io image name in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,10 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  IMAGE: ghcr.io/${{ github.repository }}
+  # Must be lowercase to be a valid Docker tag (github.repository keeps the
+  # real casing, "laurentChin", which docker/build-push-action rejects) --
+  # and must match docker-compose.yml's hardcoded image reference.
+  IMAGE: ghcr.io/laurentchin/movie-manager-api
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary

The first real `deploy.yml` run after merging #41 failed at the build-push step:

```
buildx failed with: ERROR: failed to build: invalid tag "ghcr.io/laurentChin/movie-manager-api:278432a54bed7bd1794bf4ff965d20883fc3375c": repository name must be lowercase
```

`github.repository` preserves the actual GitHub casing (`laurentChin`), but Docker image references must be all-lowercase. `docker-compose.yml` already hardcoded the correct lowercase reference (`ghcr.io/laurentchin/movie-manager-api`) — `deploy.yml` was deriving a different, wrong-cased one from `github.repository`. Hardcoded it to match instead.

No outage: the build step failed before anything was pushed or deployed, so the existing shipit/pm2 deployment kept serving traffic unaffected.

## Test plan

- [x] `actionlint` reports zero issues
- [ ] Next `deploy.yml` run (on merge) reaches the SSH/health-check steps — this is the real validation, can't be tested from here

🤖 Generated with [Claude Code](https://claude.com/claude-code)