### PR TITLE
fix: lazy-load sharp to prevent boot crash on old CPUs

### DIFF
--- a/src/movie/helpers.js
+++ b/src/movie/helpers.js
@@ -1,6 +1,5 @@
 const path = require("path");
 const util = require("util");
-const sharp = require("sharp");
 const uuid = require("uuid");
 const fs = require("fs");
 const axios = require("axios");
@@ -33,6 +32,13 @@ async function handleFile({ filename, createReadStream, assetsPath }) {
 }
 
 async function createPipeline(filename, assetsPath) {
+  // Loaded lazily: sharp's prebuilt native binary requires AVX, which the
+  // production host's CPU doesn't have. Requiring it at module load time
+  // crashed the whole process (SIGILL) before the server could even start.
+  // Deferring it here means the rest of the app works, and only poster
+  // upload/resize fails, until the underlying libvips binary is rebuilt
+  // without AVX.
+  const sharp = require("sharp");
   const [, extension] = /([a-z]{2,})$/.exec(filename);
   const name = uuid.v4();
   const finalName = `${name}.${extension}`;


### PR DESCRIPTION
## Summary

**Production incident**: the first real deploy crash-looped the container (exit 132/SIGILL) immediately on boot. Root cause: `sharp`'s prebuilt native binary requires AVX instructions, and the production host is an Intel Atom N2800 (2011, pre-AVX hardware). `require("sharp")` itself is an illegal instruction there — confirmed directly on the server:

```
$ docker run --entrypoint node <image> -e "require('sharp')"
exit 132
$ docker run --entrypoint node <image> -e "console.log('ok')"
before sharp
exit 0
```

`src/movie/helpers.js` required `sharp` at module load time, which gets pulled in transitively at server boot (`movie/resolvers.js` → `helpers.js` → `sharp`, evaluated while building the GraphQL schema) — so the entire process died before the HTTP server ever started, taking down every feature, not just image handling.

## Fix

Moved `require("sharp")` into `createPipeline()`, the only place it's actually used, so it's evaluated lazily on first poster upload instead of at boot. Everything else (login, `movies`, `search`, `explore`, `/formats`...) is unaffected and comes back immediately.

**Known limitation, tracked as a follow-up, not fixed here**: poster upload/resize will still crash the process at the moment it's invoked, until `libvips` is rebuilt without AVX (`-mno-avx -mno-avx2 -mno-avx512f`) — a real Dockerfile change (build tools + libvips build deps), not something to rush through mid-incident. Docker's `restart: unless-stopped` brings the container back automatically after that crash, so it's a brief blip rather than a lasting outage, but the feature itself won't work correctly until that follow-up lands.

## Test plan

- [x] 3 `ava` tests pass, eslint clean
- [ ] Redeploy restores the rest of the API in production — this is the actual fix validation, happens on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)