### PR TITLE
fix: read health-check port from the container, not the host

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,9 +63,11 @@ jobs:
             docker compose run --rm api npm run db:sync
             docker compose up -d
 
-            # environment.json already lives here for the pm2 deploy today,
-            # so node is a safe assumption on this host.
-            PORT=$(node -e "console.log(require('./environment.json').port)")
+            # Read the port via the container itself, not the host -- the
+            # host has no node installed (that assumption was wrong: it
+            # only ever had pm2/node for the old, now-replaced deploy
+            # method, and on this box there wasn't even that).
+            PORT=$(docker compose exec -T api node -e "console.log(require('./environment.json').port)")
             for i in $(seq 1 10); do
               if curl -sf -X POST "http://localhost:$PORT/graphql" \
                 -H "Content-Type: application/json" \

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -31,7 +31,10 @@ jobs:
 
             # No db:sync here: rolling back to an older image should not
             # re-run schema sync against a newer schema shape.
-            PORT=$(node -e "console.log(require('./environment.json').port)")
+
+            # Read the port via the container itself -- the host has no
+            # node installed.
+            PORT=$(docker compose exec -T api node -e "console.log(require('./environment.json').port)")
             for i in $(seq 1 10); do
               if curl -sf -X POST "http://localhost:$PORT/graphql" \
                 -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary

Deploy of #44 (jimp) actually succeeded — the container came up and stayed up (\`Up 2 minutes\`, no crash loop, confirmed the real fix worked). The workflow still reported failure though, purely because of the health-check step:

\`\`\`
bash: line 11: node: command not found
2026/08/15 15:51:57 Process exited with status 127
\`\`\`

My comment justifying \`node -e ...\` on the host in #41 was wrong: this host never had node/pm2 for the \`deploy\` user (that assumption carried over from the old pm2-based deploy without actually being verified against this specific host — this branch is exactly the fix for that).

**Production is fine and was fine at the time**: verified directly — the container answered GraphQL queries on the server, and \`https://api.mm.laurentjanet.fr/graphql\` (the real API domain — distinct from the PWA's \`mm.laurentjanet.fr\`, which I'd mistakenly checked first) was already responding correctly.

## Fix

Read the port through \`docker compose exec api node ...\` instead of the host directly — the container has node, the host doesn't need it. Same fix applied to both \`deploy.yml\` and \`rollback.yml\` (identical broken line in both).

## Test plan

- [x] \`actionlint\` reports zero issues
- [x] Verified against the real server with the actual \`deploy\` SSH key (not the admin account) before pushing: \`docker compose exec -T api node -e "console.log(require('./environment.json').port)"\` returns \`8082\`, and the full curl health-check that follows succeeds
- [ ] Next real \`deploy.yml\` run reaches a green health-check step — happens on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)