### PR TITLE
ci: don't deploy on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - "**.md"
   pull_request:
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds `paths-ignore: ["**.md"]` to CI's `push` trigger on `master`
- Deploy listens for CI's `workflow_run` completing, and `workflow_run` triggers don't support path filters themselves, so skipping CI entirely for docs-only pushes is what actually stops deploy from firing
- PRs are unaffected (still run CI for visibility on doc changes)

## Test plan
- YAML validated locally (`docker compose config`-equivalent not applicable; visually reviewed trigger syntax against GitHub Actions docs)
- Will confirm behavior on the next docs-only push to master (no CI/Deploy run expected) and next functional push (CI + Deploy run as before)