### PR TITLE
ci: only deploy on functional changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,16 @@ name: CI
 on:
   push:
     branches: [master]
-    paths-ignore:
-      - "**.md"
+    paths:
+      - "src/**"
+      - "scripts/**"
+      - "public/**"
+      - "environment.js"
+      - "Dockerfile"
+      - ".dockerignore"
+      - "docker-compose.yml"
+      - "package.json"
+      - "package-lock.json"
   pull_request:
 
 jobs:

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -2,6 +2,8 @@
 
 CI/CD runs through GitHub Actions (`.github/workflows/ci.yml`, `deploy.yml`, `rollback.yml`). On every push to `master` that passes CI, a Docker image is built, pushed to GitHub Container Registry (`ghcr.io/<owner>/movie-manager-api`), tagged with the commit SHA (and `latest`), then deployed to the production server over SSH.
 
+Deploy is chained off CI's `workflow_run` completing, so it only fires for pushes CI actually ran for. CI's `push` trigger is restricted to paths that affect the running application (`src/**`, `scripts/**`, `public/**`, `environment.js`, `Dockerfile`, `.dockerignore`, `docker-compose.yml`, `package.json`, `package-lock.json`) — changes limited to docs, tests, lint/editor config, or CI workflows themselves don't trigger a deploy. PRs still run CI unconditionally, for visibility.
+
 ## One-time server setup
 
 These steps have to be done manually on the production server — nothing here can be run from CI.


### PR DESCRIPTION
## Summary
- Replaces CI's `paths-ignore: ["**.md"]` with a positive `paths:` allowlist: `src/**`, `scripts/**`, `public/**`, `environment.js`, `Dockerfile`, `.dockerignore`, `docker-compose.yml`, `package.json`, `package-lock.json`
- Deploy is chained off CI's `workflow_run` completing, so this now also gates deploy — pushes touching only tests, lint/editor config, or `.github/**` no longer trigger a rebuild+redeploy (this is what happened with the shipit-removal PRs: deleting `shipitfile.js` + devDependencies shouldn't have redeployed, and now it wouldn't)
- PRs are unaffected (still run CI unconditionally, for visibility)

**Known residual gap** (discussed and accepted): package.json/package-lock.json changes still trigger deploy even when only `devDependencies` change, since GitHub Actions path filters see file paths, not diff content — narrowing further would need a content-aware check step (parsing the JSON diff), which adds real fragility for a corner case that's harmless when it does happen (redeploying an image with no actual behavior change).

## Test plan
- YAML validated (`js-yaml` load)
- Will confirm on next deploy-relevant push (CI + Deploy run) vs a docs/test-only push (neither runs)