### PR TITLE
feat: search TMDB suggestions by director

### DIFF
--- a/environment-test.json
+++ b/environment-test.json
@@ -7,5 +7,15 @@
     "appId": 138483919580948,
     "redirectUri": "",
     "appSecret": "appsecret"
+  },
+  "database": {
+    "name": "movie-manager-test",
+    "username": "test",
+    "password": "test",
+    "config": {
+      "host": "localhost",
+      "dialect": "postgres",
+      "logging": false
+    }
   }
 }

--- a/src/graphql/typeDefs.js
+++ b/src/graphql/typeDefs.js
@@ -21,7 +21,7 @@ const typeDefs = gql`
     movies(offset: Int, limit: Int): [Movie]
     movie(id: Int): Movie
     search(terms: String): [Movie]
-    explore(terms: String): [ExplorationResult]
+    explore(terms: String, byDirector: Boolean): [ExplorationResult]
     getFormats: [Format]
     logs(createdAt: String): [Log]
   }

--- a/src/movie/resolvers.js
+++ b/src/movie/resolvers.js
@@ -15,6 +15,78 @@ const { CREATE, UPDATE, DELETE } = require("../log/constants");
 
 const Sequelize = require("sequelize");
 
+/* eslint-disable camelcase */
+async function getPosterBaseUrl(environment) {
+  const {
+    data: {
+      images: { secure_base_url },
+    },
+  } = await axios.get(
+    `${MOVIE_DB_API_URL}/configuration?api_key=${environment.MOVIE_DB_API_KEY}`
+  );
+
+  return secure_base_url;
+}
+/* eslint-enable camelcase */
+
+async function getMovieDirectors(movieId, environment) {
+  const {
+    data: { crew },
+  } = await axios.get(
+    `${MOVIE_DB_API_URL}/movie/${movieId}/credits?api_key=${environment.MOVIE_DB_API_KEY}`
+  );
+
+  return crew.filter(member => member.job.toLowerCase() === "director");
+}
+
+function toExplorationResult(result, directors, posterBaseUrl) {
+  /* eslint-disable camelcase */
+  const { title, poster_path, release_date: releaseDate } = result;
+
+  return {
+    title,
+    releaseDate,
+    direction: directors.map(director => director.name).join(", "),
+    poster: poster_path ? `${posterBaseUrl}original${poster_path}` : "",
+  };
+  /* eslint-enable camelcase */
+}
+
+async function exploreByDirector(terms, environment) {
+  const {
+    data: { results: people },
+  } = await axios.get(
+    `${MOVIE_DB_API_URL}/search/person?api_key=${
+      environment.MOVIE_DB_API_KEY
+    }&query=${encodeURIComponent(terms)}&region=FR&language=fr-FR`
+  );
+
+  const [director] = people;
+
+  if (!director) return [];
+
+  const {
+    data: { results },
+  } = await axios.get(
+    `${MOVIE_DB_API_URL}/discover/movie?api_key=${
+      environment.MOVIE_DB_API_KEY
+    }&with_crew=${director.id}&region=FR&language=fr-FR`
+  );
+
+  const posterBaseUrl = await getPosterBaseUrl(environment);
+  const movies = [];
+
+  for (const result of results) {
+    const directors = await getMovieDirectors(result.id, environment);
+
+    if (!directors.some(member => member.id === director.id)) continue;
+
+    movies.push(toExplorationResult(result, directors, posterBaseUrl));
+  }
+
+  return movies;
+}
+
 const resolvers = {
   Query: {
     movie: async (parent, { id }) => mapDataValues(await Movie.findByPk(id)),
@@ -55,8 +127,13 @@ const resolvers = {
 
       return movies.map(mapDataValues);
     },
-    explore: async (parent, { terms }, { user, model, environment }) => {
-      /* eslint-disable camelcase */
+    explore: async (
+      parent,
+      { terms, byDirector = false },
+      { environment }
+    ) => {
+      if (byDirector) return exploreByDirector(terms, environment);
+
       const {
         data: { results },
       } = await axios.get(
@@ -65,40 +142,14 @@ const resolvers = {
         }&query=${encodeURIComponent(terms)}&region=FR&language=fr-FR`
       );
 
+      const posterBaseUrl = await getPosterBaseUrl(environment);
       const movies = [];
-      const {
-        data: {
-          images: { secure_base_url },
-        },
-      } = await axios.get(
-        `${MOVIE_DB_API_URL}/configuration?api_key=${environment.MOVIE_DB_API_KEY}`
-      );
 
       for (const result of results) {
-        const { id, title, poster_path, release_date: releaseDate } = result;
-        const movie = { title, releaseDate };
-        const {
-          data: { crew },
-        } = await axios.get(
-          `${MOVIE_DB_API_URL}/movie/${id}/credits?api_key=${environment.MOVIE_DB_API_KEY}`
-        );
+        const directors = await getMovieDirectors(result.id, environment);
 
-        const direction = crew.filter(member => {
-          return member.job.toLowerCase() === "director";
-        });
-
-        movie.direction = direction
-          .reduce((acc, director) => `${acc}, ${director.name}`, "")
-          .replace(", ", "");
-
-        movie.poster = poster_path
-          ? `${secure_base_url}original${poster_path}`
-          : "";
-
-        movies.push(movie);
+        movies.push(toExplorationResult(result, directors, posterBaseUrl));
       }
-
-      /* eslint-enable camelcase */
 
       return movies;
     },

--- a/tests/movie/resolvers.js
+++ b/tests/movie/resolvers.js
@@ -1,0 +1,117 @@
+const test = require("ava");
+const axios = require("axios");
+const MockAdapter = require("axios-mock-adapter");
+
+const { MOVIE_DB_API_URL } = require("../../src/movie/constants");
+const resolvers = require("../../src/movie/resolvers");
+
+const environment = { MOVIE_DB_API_KEY: "test-key" };
+const mock = new MockAdapter(axios);
+
+test.afterEach(() => {
+  mock.reset();
+});
+
+test.serial(
+  "explore with byDirector must return only movies directed by the matching person",
+  async t => {
+    mock
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/search/person`))
+      .reply(200, {
+        results: [{ id: 42, name: "Denis Villeneuve" }],
+      })
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/discover/movie`))
+      .reply(200, {
+        results: [
+          {
+            id: 1,
+            title: "Dune",
+            release_date: "2021-09-15",
+            poster_path: "/dune.jpg",
+          },
+          {
+            id: 2,
+            title: "Not Directed By Him",
+            release_date: "2020-01-01",
+            poster_path: "/other.jpg",
+          },
+        ],
+      })
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/configuration`))
+      .reply(200, {
+        images: { secure_base_url: "https://image.tmdb.org/t/p/" },
+      })
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/movie/1/credits`))
+      .reply(200, {
+        crew: [{ id: 42, name: "Denis Villeneuve", job: "Director" }],
+      })
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/movie/2/credits`))
+      .reply(200, {
+        crew: [{ id: 99, name: "Someone Else", job: "Director" }],
+      });
+
+    const movies = await resolvers.Query.explore(
+      null,
+      { terms: "Denis Villeneuve", byDirector: true },
+      { environment }
+    );
+
+    t.is(movies.length, 1);
+    t.is(movies[0].title, "Dune");
+    t.is(movies[0].direction, "Denis Villeneuve");
+    t.is(movies[0].poster, "https://image.tmdb.org/t/p/original/dune.jpg");
+  }
+);
+
+test.serial(
+  "explore with byDirector must return an empty list when no person matches",
+  async t => {
+    mock.onGet(new RegExp(`^${MOVIE_DB_API_URL}/search/person`)).reply(200, {
+      results: [],
+    });
+
+    const movies = await resolvers.Query.explore(
+      null,
+      { terms: "Unknown Person", byDirector: true },
+      { environment }
+    );
+
+    t.deepEqual(movies, []);
+  }
+);
+
+test.serial(
+  "explore without byDirector must still search movies by title",
+  async t => {
+    mock
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/search/movie`))
+      .reply(200, {
+        results: [
+          {
+            id: 1,
+            title: "Dune",
+            release_date: "2021-09-15",
+            poster_path: "/dune.jpg",
+          },
+        ],
+      })
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/configuration`))
+      .reply(200, {
+        images: { secure_base_url: "https://image.tmdb.org/t/p/" },
+      })
+      .onGet(new RegExp(`^${MOVIE_DB_API_URL}/movie/1/credits`))
+      .reply(200, {
+        crew: [{ id: 42, name: "Denis Villeneuve", job: "Director" }],
+      });
+
+    const movies = await resolvers.Query.explore(
+      null,
+      { terms: "Dune" },
+      { environment }
+    );
+
+    t.is(movies.length, 1);
+    t.is(movies[0].title, "Dune");
+    t.is(movies[0].direction, "Denis Villeneuve");
+  }
+);


### PR DESCRIPTION
## Summary
- Adds an optional `byDirector: Boolean` argument to the `explore` GraphQL query, allowing suggestions to be searched by director name instead of movie title only.
- When `byDirector` is true, resolves the person via TMDB's `/search/person`, lists their filmography via `/discover/movie`, and keeps only movies where that person is actually credited as director (via `/movie/{id}/credits`).
- Factors the shared logic (poster URL resolution, director extraction, result mapping) out of `explore` so both search modes reuse it.
- Adds a minimal `database` block to `environment-test.json`, required for tests to load `src/models` (previously nothing tested `resolvers.js` at all since it transitively requires `../models`).

## Test plan
- [x] `npm test` — 6/6 tests passing, including 3 new tests covering director search (match found, no match, and title search still working unaffected)
- [x] `eslint` clean on changed files
- [ ] Manual GraphQL query check against a live TMDB key:
  ```graphql
  query {
    explore(terms: "Denis Villeneuve", byDirector: true) {
      title
      releaseDate
      direction
      poster
    }
  }
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)